### PR TITLE
v6.1.0 Crash Fix & Data Lost

### DIFF
--- a/src/commands/server/leaderboard.js
+++ b/src/commands/server/leaderboard.js
@@ -63,12 +63,11 @@ class Leaderboard extends Command {
 			})
 
 			const author = lbData.filter(key => key.id === this.user.id)[0]
-			
 			reply(this.locale.LEADERBOARD.AUTHOR_RANK, {
 				simplified: true,
 				socket: {
 					rank: lbData.indexOf(author) + 1,
-					points: commanifier(author.points) > 1 ? commanifier(author.points) : commanifier(author.points) + 1,
+					points: commanifier(author.points) == 0 ? commanifier(author.points + 1): commanifier(author.points),
 					emoji: emoji(selectedGroup),
 				}
 			})

--- a/src/config/customConfig.js
+++ b/src/config/customConfig.js
@@ -106,6 +106,7 @@ class config {
             {"LEVEL": 100, "COLOR": `#f4e762`, "NAME":`The Creator`},
             {"LEVEL": 180, "COLOR": `#fda746`, "NAME":`Altered Pencilician`}
         ]
+        finalConfig.backupRanks = backupRanks
         if (typeof finalConfig.set_ranks == `string`) finalConfig.set_ranks = JSON.parse(finalConfig.set_ranks)
         if (finalConfig.set_ranks.length > 0){
             finalConfig.ranks = []

--- a/src/controllers/events.js
+++ b/src/controllers/events.js
@@ -18,7 +18,7 @@ module.exports = annie => {
 	annie.on(`guildBanAdd`, async (guild, user) => reqEvent(`guildBanAdd`)(annie, guild, user))
 	annie.on(`guildBanRemove`, async (guild, user) => reqEvent(`guildBanRemove`)(annie, guild, user))
 	if (!annie.dev) {
-		annie.on(`presenceUpdate`, async (oldMember, newMember) => reqEvent(`presenceUpdate`)({annie, oldMember, newMember}))
+		annie.on(`presenceUpdate`, async (oldMember, newMember) => reqEvent(`presenceUpdate`)(annie, oldMember, newMember))
 		annie.on(`reconnecting`, (annie) => reqEvent(`reconnecting`)(annie))
 		annie.on(`disconnect`, (annie) => reqEvent(`disconnect`)(annie))
 		annie.on(`guildMemberAdd`, async(member) => reqEvent(`guildMemberAdd`)(annie, member))

--- a/src/events/presenceUpdate.js
+++ b/src/events/presenceUpdate.js
@@ -1,4 +1,4 @@
-module.exports = async ({bot, newMember}) => {
+module.exports = async (bot, oldMember, newMember) => {
 
 
     /**
@@ -16,7 +16,7 @@ module.exports = async ({bot, newMember}) => {
      */
 
 
-     const moduleID = `PRESENCEUPDATE_${newMember.id}`
+    const moduleID = `PRESENCEUPDATE_${newMember.id}` || `PRESENCEUPDATE_${oldMember.id}`
     //  Return if current presence is not offline
     if (newMember.presence.status != `offline`) return
     //  To avoid performance degradation, add cooling down time before accepting next request of the same user

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -55,7 +55,7 @@ module.exports = annie => {
 		//	Change Booster Role color
 		Routine.roleChange()
 		//	Automatically change annie status
-		Routine.autoStatus()
+		//Routine.autoStatus()
 		// Remove featured daily post
 		Routine.removeFeaturedDailyPostLoop()
 	}

--- a/src/libs/database.js
+++ b/src/libs/database.js
@@ -831,6 +831,57 @@ class Database {
 	}
 
 	/**
+	 * Give some ac for the lost of levels
+	 * @param {string} [userId = ``]
+	 * @param {string} [guildId = ``] 
+	 * @returns {QueryResult}
+	 */
+	forgivenessGift(userId=``, guildId=``, level){
+		let amountRoGive = 50000
+		switch (level) {
+			case 180:
+				amountRoGive = 750000
+				break
+			case 100:
+				amountRoGive = 600000
+				break
+			case 85:
+				amountRoGive = 550000
+				break
+			case 70:
+				amountRoGive = 500000
+				break
+			case 60:
+				amountRoGive = 450000
+				break
+			case 50:
+				amountRoGive = 400000
+				break
+			case 45:
+				amountRoGive = 350000
+				break
+			case 40:
+				amountRoGive = 300000
+				break
+			case 35:
+				amountRoGive = 250000
+				break
+			case 30:
+				amountRoGive = 200000
+				break
+			case 25:
+				amountRoGive = 150000
+				break
+			case 20:
+				amountRoGive = 100000
+				break
+			default:
+				break
+		}
+		this.updateInventory({itemId: 52, value: amountRoGive, operation: `+`, userId: userId, guildId: guildId})
+	}
+
+	/**
 	 * Setting user's experience points into `user_exp` table
 	 * @param {number} [amount=0] amount to be added
 	 * @param {string} [userId=``] target user's discord id

--- a/src/libs/database.js
+++ b/src/libs/database.js
@@ -829,7 +829,23 @@ class Database {
 			, [amount, userId, guildId]
 		)
 	}
-	
+
+	/**
+	 * Setting user's experience points into `user_exp` table
+	 * @param {number} [amount=0] amount to be added
+	 * @param {string} [userId=``] target user's discord id
+	 * @returns {QueryResult}
+	 */
+	setUserExp(amount=0, userId=``, guildId=``) {
+		return this._query(`
+			UPDATE user_exp 
+			SET current_exp = ?
+			WHERE user_id = ? AND guild_id = ?`
+			, `run`
+			, [amount, userId, guildId]
+		)
+	}
+
 	/**
 	 * Pull user's strike records if presents.
 	 * @param {string} [userId=``] target user's discord id

--- a/src/libs/exp.js
+++ b/src/libs/exp.js
@@ -57,6 +57,7 @@ class Experience extends Points {
 			let xpToAdd = await this.xpReverseFormula(roleLevel)
 			if (this.exp.current_exp < xpToAdd.maxexp) await this.db.addUserExp(Math.round(xpToAdd.maxexp), this.message.author.id, this.message.guild.id)
 			if (!this.exp.current_exp) await this.db.setUserExp(Math.round(xpToAdd.maxexp), this.message.author.id, this.message.guild.id)
+			if ((this.exp.current_exp < xpToAdd.maxexp) || !this.exp.current_exp) await this.db.forgivenessGift(this.message.author.id, this.message.guild.id, roleLevel)
 		}
     	//  Apply booster if presents
     	if (this.exp.booster_id) await this.applyBooster()

--- a/src/libs/exp.js
+++ b/src/libs/exp.js
@@ -34,7 +34,30 @@ class Experience extends Points {
      */
     async execute(expToBeAdded=this.baseGainedExp) {
     	this.exp = await this.db.getUserExp(this.message.author.id, this.message.guild.id)
-
+		if (this.message.guild.id == `459891664182312980`) {
+			let user = this.message.author
+			let roles = []
+			for (let index = 0; index < user.lastMessage.member._roles.length; index++) {
+				const element = user.lastMessage.member._roles[index]
+				roles.push(this.message.guild.roles.get(element).name)
+			}
+			let role, roleLevel
+			for (let index = 0; index < this.bot.backupRanks.length; index++) {
+				const element = this.bot.backupRanks[index].NAME
+				for (let j = 0; j < roles.length; j++) {
+					const element2 = roles[j]
+					if (element == element2) {
+						role = element
+						roleLevel = this.bot.backupRanks[index].LEVEL
+						break
+					}
+					if (role) break
+				}
+			}
+			let xpToAdd = await this.xpReverseFormula(roleLevel)
+			if (this.exp.current_exp < xpToAdd.maxexp) await this.db.addUserExp(Math.round(xpToAdd.maxexp), this.message.author.id, this.message.guild.id)
+			if (!this.exp.current_exp) await this.db.setUserExp(Math.round(xpToAdd.maxexp), this.message.author.id, this.message.guild.id)
+		}
     	//  Apply booster if presents
     	if (this.exp.booster_id) await this.applyBooster()
 

--- a/src/libs/routines.js
+++ b/src/libs/routines.js
@@ -51,6 +51,12 @@ class Routines {
      */
 	roleChange() {
 
+		/**
+		 * Pan: I think i know a way to bring this to all servers will work on at a later date
+		 * 
+		 * 
+		 * 
+		 */
 		const client = this.client
 		const logger = this.logger
 		/**
@@ -179,7 +185,7 @@ class Routines {
 	/**
      *  Automatically change current this.client status presence
      *  @autoStatus
-     */
+     *//*
 	autoStatus() {
 		const client = this.client
 		const logger = this.logger
@@ -298,7 +304,7 @@ class Routines {
 			}
 		}
     }
-    
+    */
 
     /**
      *  Automatically record resource usage data every 5 min.


### PR DESCRIPTION
I believe these bugs were causing Annie to be unresponsive and ultimately led me to "turn off Annie"
Bugs:
(crashing one ) undefined variable in presenceUpdate
(crashing one) auto status routine calling nonexistent function
Leaderboard showing the wrong amount of ac
New:
For users on AAU when they type, it will grab their highest rank role, retrieve the level associated with it and then calculate the correct XP and add it to them allowing old and new XP to be combined. In addition to this ca is compensated based on level. For example, level 100 will get 600000 AC, level 85 will get 550000 AC, and so on, each rank goes down by 50000 AC (100 to 20), any rank below 20 will get 50000